### PR TITLE
MP-66 Make internal tools work on the marketplace namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,11 @@
     "cs-fix": "phpcbf --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml -v src/ tests/ --ignore='/Fixtures/'",
     "phpstan": "phpstan analyse -l 7 -c phpstan.neon src/"
   },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "0.1.x-dev"
+    }
+  },
   "config": {
     "use-include-path": true,
     "process-timeout": 600,


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/MP-66

Minor:
[spryker-sdk/spryk-gui#12](https://github.com/spryker-sdk/spryk-gui/pull/12) /merged
[spryker-sdk/phpstan-spryker#8](https://github.com/spryker-sdk/phpstan-spryker/pull/8) /merged
[spryker-sdk/spryk#12](https://github.com/spryker-sdk/spryk/pull/12) /merged
[spryker/git-hook#25](https://github.com/spryker/git-hook/pull/25) /merged
[spryker/spryker-shop#794](https://github.com/spryker/spryker-shop/pull/794) /merged

Suites:
[spryker/suite-nonsplit#1823](https://github.com/spryker/suite-nonsplit/pull/1823)
[spryker/merchant-portal-nonsplit#2](https://github.com/spryker/merchant-portal-nonsplit/pull/2)