### PR TITLE
TE-1840 fixed outdated templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spryker Spryk
+# Spryk Module
 
 [![Build Status](https://travis-ci.com/spryker/spryk.svg?token=7jVDNZFJxpvBrFetYhbF&branch=master)](https://travis-ci.com/spryker/spryk)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/spryker/spryk/badges/quality-score.png?b=master&s=ebca747a3c5798a911ff1beaae498b6101af74f6)](https://scrutinizer-ci.com/g/spryker/spryk/?branch=master)

--- a/codeception.yml
+++ b/codeception.yml
@@ -10,7 +10,7 @@ paths:
 
 settings:
     bootstrap: _bootstrap.php
-    suite_class: \PHPUnit_Framework_TestSuite
+    suite_class: \PHPUnit\Framework\TestSuite
     colors: true
     memory_limit: 2048M
     log: true

--- a/config/spryk/templates/Zed/ZedDependencyProvider.php.twig
+++ b/config/spryk/templates/Zed/ZedDependencyProvider.php.twig
@@ -9,6 +9,9 @@ namespace {{ organization }}\Zed\{{ module }};
 
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 
+/**
+ * @method \{{ organization }}\Zed\{{ module }}\{{ module }}Config getConfig()
+ */
 class {{ module }}DependencyProvider extends AbstractBundleDependencyProvider
 {
 }

--- a/config/spryk/templates/codeception.yml.twig
+++ b/config/spryk/templates/codeception.yml.twig
@@ -9,7 +9,7 @@ paths:
     envs: tests/_envs
 settings:
     bootstrap: _bootstrap.php
-    suite_class: \PHPUnit_Framework_TestSuite
+    suite_class: \PHPUnit\Framework\TestSuite
     colors: true
     memory_limit: 1024M
     log: true

--- a/config/spryk/templates/composer.json.twig
+++ b/config/spryk/templates/composer.json.twig
@@ -3,7 +3,12 @@
   "description": "{{ module }} module",
   "license": "proprietary",
   "require": {
-    "php": ">=7.1"
+    "php": ">=7.1",
+    "spryker/kernel": "^3.0.0"
+  },
+  "require-dev": {
+    "spryker/code-sniffer": "*",
+    "spryker/testify": "*"
   },
   "autoload": {
     "psr-4": {

--- a/config/spryk/templates/gitattributes.twig
+++ b/config/spryk/templates/gitattributes.twig
@@ -23,6 +23,8 @@
 # Remove files for archives generated using `git archive`
 codeception.yml export-ignore
 dependency.json export-ignore
+phpstan.json export-ignore
+phpstan.neon export-ignore
 tooling.yml export-ignore
 .coveralls.yml export-ignore
 .travis.yml export-ignore

--- a/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/Argument.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/Argument.php
@@ -27,9 +27,9 @@ class Argument implements ArgumentInterface
     /**
      * @param string $name
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\ArgumentInterface
+     * @return $this
      */
-    public function setName(string $name): ArgumentInterface
+    public function setName(string $name)
     {
         $this->name = $name;
 
@@ -55,9 +55,9 @@ class Argument implements ArgumentInterface
     /**
      * @param mixed $value
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\ArgumentInterface
+     * @return $this
      */
-    public function setValue($value): ArgumentInterface
+    public function setValue($value)
     {
         $this->value = $value;
 
@@ -75,9 +75,9 @@ class Argument implements ArgumentInterface
     /**
      * @param array $callbacks
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\ArgumentInterface
+     * @return $this
      */
-    public function setCallbacks(array $callbacks): ArgumentInterface
+    public function setCallbacks(array $callbacks)
     {
         $this->callbacks = $callbacks;
 

--- a/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/ArgumentInterface.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/ArgumentInterface.php
@@ -12,9 +12,9 @@ interface ArgumentInterface
     /**
      * @param string $name
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\ArgumentInterface
+     * @return $this
      */
-    public function setName(string $name): self;
+    public function setName(string $name);
 
     /**
      * @return string
@@ -24,9 +24,9 @@ interface ArgumentInterface
     /**
      * @param mixed $value
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\ArgumentInterface
+     * @return $this
      */
-    public function setValue($value): self;
+    public function setValue($value);
 
     /**
      * @return mixed
@@ -36,9 +36,9 @@ interface ArgumentInterface
     /**
      * @param array $callbacks
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\ArgumentInterface
+     * @return $this
      */
-    public function setCallbacks(array $callbacks): self;
+    public function setCallbacks(array $callbacks);
 
     /**
      * @return string[]

--- a/src/SprykerSdk/Spryk/Model/Spryk/Definition/Builder/SprykDefinitionBuilder.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Definition/Builder/SprykDefinitionBuilder.php
@@ -73,9 +73,9 @@ class SprykDefinitionBuilder implements SprykDefinitionBuilderInterface
     /**
      * @param \SprykerSdk\Spryk\Style\SprykStyleInterface $style
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Builder\SprykDefinitionBuilderInterface
+     * @return $this
      */
-    public function setStyle(SprykStyleInterface $style): SprykDefinitionBuilderInterface
+    public function setStyle(SprykStyleInterface $style)
     {
         $this->style = $style;
 

--- a/src/SprykerSdk/Spryk/Model/Spryk/Definition/Builder/SprykDefinitionBuilderInterface.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Definition/Builder/SprykDefinitionBuilderInterface.php
@@ -23,7 +23,7 @@ interface SprykDefinitionBuilderInterface
     /**
      * @param \SprykerSdk\Spryk\Style\SprykStyleInterface $style
      *
-     * @return \SprykerSdk\Spryk\Model\Spryk\Definition\Builder\SprykDefinitionBuilderInterface
+     * @return $this
      */
-    public function setStyle(SprykStyleInterface $style): self;
+    public function setStyle(SprykStyleInterface $style);
 }

--- a/src/SprykerSdk/Spryk/SprykFacade.php
+++ b/src/SprykerSdk/Spryk/SprykFacade.php
@@ -53,9 +53,9 @@ class SprykFacade implements SprykFacadeInterface
     /**
      * @param \SprykerSdk\Spryk\SprykFactory $factory
      *
-     * @return \SprykerSdk\Spryk\SprykFacadeInterface
+     * @return $this
      */
-    public function setFactory(SprykFactory $factory): SprykFacadeInterface
+    public function setFactory(SprykFactory $factory)
     {
         $this->factory = $factory;
 

--- a/src/SprykerSdk/Spryk/SprykFacadeInterface.php
+++ b/src/SprykerSdk/Spryk/SprykFacadeInterface.php
@@ -28,9 +28,9 @@ interface SprykFacadeInterface
     /**
      * @param \SprykerSdk\Spryk\SprykFactory $factory
      *
-     * @return \SprykerSdk\Spryk\SprykFacadeInterface
+     * @return $this
      */
-    public function setFactory(SprykFactory $factory): self;
+    public function setFactory(SprykFactory $factory);
 
     /**
      * @param array $argumentsList


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-1840

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

#### Release Notes

This patch will update some templates to be used for generating files. The composer.json now contains by default `spryker/kernel` in require, `spryker/code-sniffer` and `spryker/testify` in require-dev. The `codeception.yml` now uses the psr-4 namespace for PHPUnit. The generated *DependencyProvider contains now the `@method` annotation for the `getConfig()` method.

-----------------------------------------

#### Module Spryk

##### Change log

Bugfixes

- Updated `composer.json.twig`.
- Updated `codeception.yml.twig`.
- Updated `ZedDependencyProvider.php.twig`.

