### PR TITLE
TE-1845 Updated PSR-0 to PSR-4 namespaces

### DIFF
--- a/src/SprykerSdk/Spryk/Model/Spryk/Builder/Template/Extension/TwigFilterExtension.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Builder/Template/Extension/TwigFilterExtension.php
@@ -8,7 +8,7 @@
 namespace SprykerSdk\Spryk\Model\Spryk\Builder\Template\Extension;
 
 use Twig\Extension\AbstractExtension;
-use Twig_SimpleFilter;
+use Twig\TwigFilter;
 
 class TwigFilterExtension extends AbstractExtension
 {
@@ -26,13 +26,13 @@ class TwigFilterExtension extends AbstractExtension
     }
 
     /**
-     * @return \Twig_SimpleFilter[]
+     * @return \Twig\TwigFilter[]
      */
     public function getFilters(): array
     {
         $filters = [];
         foreach ($this->filters as $filter) {
-            $filters[] = new Twig_SimpleFilter($filter->getName(), function (string $value) use ($filter) {
+            $filters[] = new TwigFilter($filter->getName(), function (string $value) use ($filter) {
                 return $filter->filter($value);
             });
         }

--- a/src/SprykerSdk/Spryk/Model/Spryk/Builder/Template/Renderer/TemplateRenderer.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Builder/Template/Renderer/TemplateRenderer.php
@@ -83,7 +83,7 @@ class TemplateRenderer implements TemplateRendererInterface
     }
 
     /**
-     * @return \Twig_LoaderInterface
+     * @return \Twig\Loader\LoaderInterface
      */
     protected function getLoader()
     {


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-1845

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x) {skip}  |                       |

#### Release Notes

Twig added proper class_aliases for all PSR-0 namespaces and we adopted all usages of Twig to make use of the PSR-4 namespace.

-----------------------------------------

#### Module Spryk

##### Change log

Improvements

- Replaced usage of PSR-0 with PSR-4 namespaces for Twig.

