### PR TITLE
TE-4334 PHP 7.1 dropping (PHP7.2+ from now on)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: '7.1'
+        php: '7.2'
 
     tests:
         override:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 sudo: false
 
 php:
-  - 7.1
+  - 7.2
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 matrix:
   include:
-  - php: 7.1
+  - php: 7.2
     env: PREFER_LOWEST=1
 
   - php: 7.3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spryk Module
 
 [![Build Status](https://travis-ci.org/spryker-sdk/spryk.svg?branch=master)](https://travis-ci.org/spryker-sdk/spryk)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.1-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg)](https://php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat)](https://github.com/phpstan/phpstan)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Spryk module",
   "license": "proprietary",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "roave/better-reflection": "^2.0 || ^3.0",
     "spryker/config": "^3.0.0",
     "spryker/doctrine-inflector": "^1.0.0",

--- a/config/spryk/templates/composer.json.twig
+++ b/config/spryk/templates/composer.json.twig
@@ -3,8 +3,8 @@
   "description": "{{ module }} module",
   "license": "proprietary",
   "require": {
-    "php": ">=7.1",
-    "spryker/kernel": "^3.0.0"
+    "php": ">=7.2",
+    "spryker/kernel": "^3.30.0"
   },
   "require-dev": {
     "spryker/code-sniffer": "*",

--- a/config/spryk/templates/scrutinizer.yml.twig
+++ b/config/spryk/templates/scrutinizer.yml.twig
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: '7.1'
+        php: '7.2'
 
     dependencies:
         before:

--- a/config/spryk/templates/travis.yml.twig
+++ b/config/spryk/templates/travis.yml.twig
@@ -1,7 +1,7 @@
 language: php
 
 php:
-    - 7.1
+    - 7.2
 
 cache:
     directories:


### PR DESCRIPTION
- Developer(s): @gechetspr

- Ticket: https://spryker.atlassian.net/browse/TE-4334

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Spryk

##### Change log

Improvement

- Raised minimum required version of `php` in `composer.json.twig` template to `7.2`.
- Raised minimum required version of `php` in `.travis.yml.twig` template to `7.2`.
- Raised minimum required version of `php` in `.scrutinizer.yml.twig` template to `7.2`.
- Raised minimum required version of `spryker/kernel` in `composer.json.twig` template to `3.30.0`.

