### PR TITLE
fix(git): remove *.ts files from binary list

### DIFF
--- a/config/spryk/templates/gitattributes.twig
+++ b/config/spryk/templates/gitattributes.twig
@@ -17,7 +17,6 @@
 *.mo binary
 *.pdf binary
 *.xsd binary
-*.ts binary
 *.exe binary
 
 # Remove files for archives generated using `git archive`


### PR DESCRIPTION
- Developer(s): @gund

- Ticket: N/A

- Academy PR: N/A

- Release Group: URL_HERE


#### Please confirm

- [x] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Spryk

##### Change log

Fixes

- Removed `*.ts` files from binary list of gitattributes

