### PR TITLE
TE 5961 deprecated container methods are still used in the code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "nette/utils": "^2.5.0",
     "php-coveralls/php-coveralls": "^1.0",
     "phpstan/phpstan": "^0.12.0",
-    "phpunit/phpunit": "^7.0.0",
+    "phpunit/phpunit": "^7.0.0 || ^8.0.0",
     "sllh/composer-versions-check": "^2.0",
     "spryker/code-sniffer": "*",
     "spryker/testify": "*"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "nette/utils": "^2.5.0",
     "php-coveralls/php-coveralls": "^1.0",
     "phpstan/phpstan": "^0.12.0",
+    "phpunit/phpunit": "^7.0.0",
     "sllh/composer-versions-check": "^2.0",
     "spryker/code-sniffer": "*",
     "spryker/testify": "*"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "proprietary",
   "require": {
     "php": ">=7.2",
-    "roave/better-reflection": "^3.0",
+    "roave/better-reflection": "^3.0 || ^4.0",
     "spryker/config": "^3.0.0",
     "spryker/doctrine-inflector": "^1.0.0",
     "spryker/glue-application-extension": "^1.1.0",
@@ -23,7 +23,6 @@
     "nette/utils": "^2.5.0",
     "php-coveralls/php-coveralls": "^1.0",
     "phpstan/phpstan": "^0.12.0",
-    "phpunit/phpunit": "^7.0.0",
     "sllh/composer-versions-check": "^2.0",
     "spryker/code-sniffer": "*",
     "spryker/testify": "*"

--- a/config/spryk/templates/Yves/Dependency/Client/YvesDependencyClientDependencyProviderMethod.php.twig
+++ b/config/spryk/templates/Yves/Dependency/Client/YvesDependencyClientDependencyProviderMethod.php.twig
@@ -4,13 +4,13 @@
      */
     protected function {{ providerMethod }}(\Spryker\Yves\Kernel\Container $container): \Spryker\Yves\Kernel\Container
     {
-        $container[static::CLIENT_{{ dependentModule | underscored | upper }}] = function (\Spryker\Yves\Kernel\Container $container) {
+        $container->set(static::CLIENT_{{ dependentModule | underscored | upper }}, function (\Spryker\Yves\Kernel\Container $container) {
             ${{ module | lcfirst }}To{{ dependentModule }}ClientBridge = new \{{ organization }}\Yves\{{ module }}\Dependency\Client\{{ module }}To{{ dependentModule }}ClientBridge(
                 $container->getLocator()->{{ dependentModule | lcfirst }}()->client()
             );
 
             return ${{ module | lcfirst }}To{{ dependentModule }}ClientBridge;
-        };
+        });
 
         return $container;
     }

--- a/config/spryk/templates/Yves/Dependency/Service/YvesDependencyServiceDependencyProviderMethod.php.twig
+++ b/config/spryk/templates/Yves/Dependency/Service/YvesDependencyServiceDependencyProviderMethod.php.twig
@@ -4,13 +4,13 @@
      */
     protected function {{ providerMethod }}(\Spryker\Yves\Kernel\Container $container): \Spryker\Yves\Kernel\Container
     {
-        $container[static::SERVICE_{{ dependentModule | underscored | upper }}] = function (\Spryker\Yves\Kernel\Container $container) {
+        $container->set(static::SERVICE_{{ dependentModule | underscored | upper }}, function (\Spryker\Yves\Kernel\Container $container) {
             ${{ module | lcfirst }}To{{ dependentModule }}ServiceBridge = new \{{ organization }}\Yves\{{ module }}\Dependency\Service\{{ module }}To{{ dependentModule }}ServiceBridge(
                 $container->getLocator()->{{ dependentModule | lcfirst }}()->service()
             );
 
             return ${{ module | lcfirst }}To{{ dependentModule }}ServiceBridge;
-        };
+        });
 
         return $container;
     }

--- a/config/spryk/templates/Zed/Dependency/Client/ZedDependencyClientDependencyProviderMethod.php.twig
+++ b/config/spryk/templates/Zed/Dependency/Client/ZedDependencyClientDependencyProviderMethod.php.twig
@@ -4,13 +4,13 @@
      */
     protected function {{ providerMethod }}(\Spryker\Zed\Kernel\Container $container): \Spryker\Zed\Kernel\Container
     {
-        $container[static::CLIENT_{{ dependentModule | underscored | upper }}] = function (\Spryker\Zed\Kernel\Container $container) {
+        $container->set(static::CLIENT_{{ dependentModule | underscored | upper }}, function (\Spryker\Zed\Kernel\Container $container) {
             ${{ module | lcfirst }}To{{ dependentModule }}ClientBridge = new \{{ organization }}\Zed\{{ module }}\Dependency\Client\{{ module }}To{{ dependentModule }}ClientBridge(
                 $container->getLocator()->{{ dependentModule | lcfirst }}()->client()
             );
 
             return ${{ module | lcfirst }}To{{ dependentModule }}ClientBridge;
-        };
+        });
 
         return $container;
     }

--- a/config/spryk/templates/Zed/Dependency/Facade/ZedDependencyFacadeDependencyProviderMethod.php.twig
+++ b/config/spryk/templates/Zed/Dependency/Facade/ZedDependencyFacadeDependencyProviderMethod.php.twig
@@ -4,13 +4,13 @@
      */
     protected function {{ providerMethod }}(\Spryker\Zed\Kernel\Container $container): \Spryker\Zed\Kernel\Container
     {
-        $container[static::FACADE_{{ dependentModule | underscored | upper }}] = function (\Spryker\Zed\Kernel\Container $container) {
+        $container->set(static::FACADE_{{ dependentModule | underscored | upper }}, function (\Spryker\Zed\Kernel\Container $container) {
             ${{ module | lcfirst }}To{{ dependentModule }}FacadeBridge = new \{{ organization }}\Zed\{{ module }}\Dependency\Facade\{{ module }}To{{ dependentModule }}FacadeBridge(
                 $container->getLocator()->{{ dependentModule | lcfirst }}()->facade()
             );
 
             return ${{ module | lcfirst }}To{{ dependentModule }}FacadeBridge;
-        };
+        });
 
         return $container;
     }

--- a/config/spryk/templates/Zed/Dependency/Service/ZedDependencyServiceDependencyProviderMethod.php.twig
+++ b/config/spryk/templates/Zed/Dependency/Service/ZedDependencyServiceDependencyProviderMethod.php.twig
@@ -4,13 +4,13 @@
      */
     protected function {{ providerMethod }}(\Spryker\Zed\Kernel\Container $container): \Spryker\Zed\Kernel\Container
     {
-        $container[static::SERVICE_{{ dependentModule | underscored | upper }}] = function (\Spryker\Zed\Kernel\Container $container) {
+        $container->set(static::SERVICE_{{ dependentModule | underscored | upper }}, function (\Spryker\Zed\Kernel\Container $container) {
             ${{ module | lcfirst }}To{{ dependentModule }}ServiceBridge = new \{{ organization }}\Zed\{{ module }}\Dependency\Service\{{ module }}To{{ dependentModule }}ServiceBridge(
                 $container->getLocator()->{{ dependentModule | lcfirst }}()->service()
             );
 
             return ${{ module | lcfirst }}To{{ dependentModule }}ServiceBridge;
-        };
+        });
 
         return $container;
     }

--- a/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/Resolver/ArgumentResolver.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/Resolver/ArgumentResolver.php
@@ -46,8 +46,11 @@ class ArgumentResolver implements ArgumentResolverInterface
      * @param \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\Superseder\SupersederInterface $superseder
      * @param \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\Callback\Resolver\CallbackArgumentResolverInterface $callbackArgumentResolver
      */
-    public function __construct(ArgumentCollectionInterface $argumentCollection, SupersederInterface $superseder, CallbackArgumentResolverInterface $callbackArgumentResolver)
-    {
+    public function __construct(
+        ArgumentCollectionInterface $argumentCollection,
+        SupersederInterface $superseder,
+        CallbackArgumentResolverInterface $callbackArgumentResolver
+    ) {
         $this->argumentCollection = $argumentCollection;
         $this->resolvedArgumentCollection = clone $argumentCollection;
         $this->superseder = $superseder;

--- a/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/Superseder/Superseder.php
+++ b/src/SprykerSdk/Spryk/Model/Spryk/Definition/Argument/Superseder/Superseder.php
@@ -58,8 +58,11 @@ class Superseder implements SupersederInterface
      *
      * @return void
      */
-    protected function resolveArgument(ArgumentInterface $argument, ArgumentCollectionInterface $sprykArguments, ArgumentCollectionInterface $resolvedArguments): void
-    {
+    protected function resolveArgument(
+        ArgumentInterface $argument,
+        ArgumentCollectionInterface $sprykArguments,
+        ArgumentCollectionInterface $resolvedArguments
+    ): void {
         $argumentValue = $argument->getValue();
 
         if (!is_array($argumentValue)) {
@@ -84,8 +87,11 @@ class Superseder implements SupersederInterface
      *
      * @return string
      */
-    protected function replacePlaceholderInValue(string $argumentValue, ArgumentCollectionInterface $sprykArguments, ArgumentCollectionInterface $resolvedArguments): string
-    {
+    protected function replacePlaceholderInValue(
+        string $argumentValue,
+        ArgumentCollectionInterface $sprykArguments,
+        ArgumentCollectionInterface $resolvedArguments
+    ): string {
         preg_match_all(static::PLACEHOLDER_PATTERN, $argumentValue, $matches, PREG_SET_ORDER);
 
         if (count($matches) === 0) {


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-5961

- Overview: https://release.spryker.com/release/pull-request-sdk/Spryk/44

- Release Group: https://release.spryker.com/release-groups/view/2689


#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Spryk

##### Change log

Fixes

- Refactored Spryks to use `ContainerInterface::set()` methods instead of array access.

