### PR TITLE
TE-5394 Twig v3 Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "symfony/filesystem": "^3.4.0 || ^4.0.0 || ^5.0.0",
     "symfony/finder": "^3.4.0 || ^4.0.0 || ^5.0.0",
     "symfony/yaml": "^3.4.9 || ^4.0.0 || ^5.0.0",
-    "twig/twig": "^1.34 || ^2.0.0",
+    "twig/twig": "^1.41 || ^2.0.0 || ^3.0.0",
     "zendframework/zend-filter": "^2.8"
   },
   "require-dev": {

--- a/config/spryk/templates/Glue/GlueFactoryMethod.php.twig
+++ b/config/spryk/templates/Glue/GlueFactoryMethod.php.twig
@@ -1,10 +1,10 @@
-{%- spaceless -%}
+{%- apply spaceless -%}
     {% if subDirectory is defined and subDirectory.value is not null %}
         {% set subDirectory = '\\' ~ subDirectory | replace({"/": "\\"}) %}
     {% else %}
         {% set subDirectory = '' %}
     {% endif %}
-{%- endspaceless -%}
+{%- endapply -%}
 
 {% if not dependencyMethods.value %}
     /**
@@ -22,13 +22,13 @@
     {
         return new \{{ organization }}\Glue\{{ module }}\Processor{{ subDirectory }}\{{ className }}(
         {% for dependencyMethod in dependencyMethods.value -%}
-            {%- spaceless -%}
+            {%- apply spaceless -%}
                 {% set endOfLine = '' %}
                 {% if not loop.last %}
                     {% set endOfLine = ',' %}
                 {% endif %}
                 {% set line = '    $this->' ~ dependencyMethod ~ '()' ~ endOfLine %}
-            {%- endspaceless -%}
+            {%- endapply -%}
             {{ line | raw }}
         {% endfor -%}
         );

--- a/config/spryk/templates/Zed/Business/MethodBusinessFactory.php.twig
+++ b/config/spryk/templates/Zed/Business/MethodBusinessFactory.php.twig
@@ -15,13 +15,13 @@
     {
         return new \{{ organization }}\Zed\{{ module }}\Business\{% if subDirectory %}{{ subDirectory | replace({"/": "\\"}) }}\{% endif %}{{ className }}(
         {% for dependencyMethod in dependencyMethods.value -%}
-            {%- spaceless -%}
+            {%- apply spaceless -%}
                 {% set endofline = '' %}
                 {% if not loop.last %}
                     {% set endofline = ',' %}
                 {% endif %}
                 {% set line = '    $this->' ~ dependencyMethod ~ '()' ~ endofline %}
-            {%- endspaceless -%}
+            {%- endapply -%}
             {{ line | raw }}
         {% endfor -%}
         );


### PR DESCRIPTION
- Developer(s): @gechetspr

- Ticket: https://spryker.atlassian.net/browse/TE-5394

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/2999


#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Spryk

##### Change log

Improvements

- Allowed version 2 and 3 of `twig/twig` in composer.
- Adjusted `GlueFactoryMethod.php.twig` in order to use `apply spaceless` instead of deprecated plain `spaceless`.
- Adjusted `MethodBusinessFactory.php.twig` in order to use `apply spaceless` instead of deprecated plain `spaceless`.

