### PR TITLE
SDK-135: For support standalone

### DIFF
--- a/bin/spryk-run
+++ b/bin/spryk-run
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 
-foreach ([__DIR__ . '/../../../../../autoload.php', __DIR__ . '/../../../autoload.php'] as $file) {
+define('SPRYKER_ROOT', getcwd());
+
+foreach ([SPRYKER_ROOT . '/vendor/autoload.php', __DIR__ . '/../../../../../autoload.php', __DIR__ . '/../../../autoload.php'] as $file) {
     if (file_exists($file)) {
         define('SPRYKER_COMPOSER_INSTALL', $file);
         define('APPLICATION_ROOT_DIR', realpath(dirname($file) . '/..'));
@@ -14,8 +16,6 @@ unset($file);
 if (!defined('SPRYKER_COMPOSER_INSTALL')) {
     throw new \Exception('Could not resolve path to vendor/autoload.php');
 }
-
-define('SPRYKER_ROOT', getcwd());
 
 require_once SPRYKER_COMPOSER_INSTALL;
 

--- a/src/SprykerSdk/Spryk/SprykConfig.php
+++ b/src/SprykerSdk/Spryk/SprykConfig.php
@@ -193,7 +193,7 @@ class SprykConfig
      */
     public function getProjectNamespace(): ?string
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACE, ['Pyz']);
+        return Config::get(KernelConstants::PROJECT_NAMESPACE, 'Pyz');
     }
 
     /**

--- a/src/SprykerSdk/Spryk/SprykConfig.php
+++ b/src/SprykerSdk/Spryk/SprykConfig.php
@@ -192,9 +192,9 @@ class SprykConfig
     public function getCoreNamespaces(): array
     {
         $namespaces = [];
+        /** @var string $namespacesFromEnv */
         $namespacesFromEnv = getenv('CORE_NAMESPACES');
         if ($namespacesFromEnv) {
-            /** @var string $namespacesFromEnv */
             $namespaces = explode(',', $namespacesFromEnv);
         }
 
@@ -218,9 +218,9 @@ class SprykConfig
     public function getProjectNamespaces(): array
     {
         $namespaces = [];
+        /** @var string $namespacesFromEnv */
         $namespacesFromEnv = getenv('PROJECT_NAMESPACES');
         if ($namespacesFromEnv) {
-            /** @var string $namespacesFromEnv */
             $namespaces = explode(',', $namespacesFromEnv);
         }
 

--- a/src/SprykerSdk/Spryk/SprykConfig.php
+++ b/src/SprykerSdk/Spryk/SprykConfig.php
@@ -180,12 +180,10 @@ class SprykConfig
      */
     public function getCoreNamespaces(): array
     {
-        return Config::get(KernelConstants::CORE_NAMESPACES, [
-            'SprykerShop',
-            'SprykerEco',
-            'Spryker',
-            'SprykerSdk',
-        ]);
+        return Config::get(
+            KernelConstants::CORE_NAMESPACES,
+            getenv('CORE_NAMESPACES') ? explode(',', getenv('CORE_NAMESPACES')) : []
+        );
     }
 
     /**
@@ -193,7 +191,7 @@ class SprykConfig
      */
     public function getProjectNamespace(): ?string
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACE, 'Pyz');
+        return Config::get(KernelConstants::PROJECT_NAMESPACE, getenv('PROJECT_NAMESPACE') ?:'');
     }
 
     /**
@@ -201,7 +199,10 @@ class SprykConfig
      */
     public function getProjectNamespaces(): array
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACES, ['Pyz']);
+        return Config::get(
+            KernelConstants::PROJECT_NAMESPACES,
+            getenv('PROJECT_NAMESPACES') ? explode(',', getenv('PROJECT_NAMESPACES')) : []
+        );
     }
 
     /**

--- a/src/SprykerSdk/Spryk/SprykConfig.php
+++ b/src/SprykerSdk/Spryk/SprykConfig.php
@@ -180,7 +180,12 @@ class SprykConfig
      */
     public function getCoreNamespaces(): array
     {
-        return Config::get(KernelConstants::CORE_NAMESPACES, []);
+        return Config::get(KernelConstants::CORE_NAMESPACES, [
+            'SprykerShop',
+            'SprykerEco',
+            'Spryker',
+            'SprykerSdk',
+        ]);
     }
 
     /**
@@ -188,7 +193,7 @@ class SprykConfig
      */
     public function getProjectNamespace(): ?string
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACE);
+        return Config::get(KernelConstants::PROJECT_NAMESPACE, ['Pyz']);
     }
 
     /**
@@ -196,7 +201,7 @@ class SprykConfig
      */
     public function getProjectNamespaces(): array
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACES, []);
+        return Config::get(KernelConstants::PROJECT_NAMESPACES, ['Pyz']);
     }
 
     /**

--- a/src/SprykerSdk/Spryk/SprykConfig.php
+++ b/src/SprykerSdk/Spryk/SprykConfig.php
@@ -191,9 +191,16 @@ class SprykConfig
      */
     public function getCoreNamespaces(): array
     {
+        $namespaces = [];
+        $namespacesFromEnv = getenv('CORE_NAMESPACES');
+        if ($namespacesFromEnv) {
+            /** @var string $namespacesFromEnv */
+            $namespaces = explode(',', $namespacesFromEnv);
+        }
+
         return Config::get(
             KernelConstants::CORE_NAMESPACES,
-            getenv('CORE_NAMESPACES') ? explode(',', getenv('CORE_NAMESPACES')) : [],
+            $namespaces,
         );
     }
 
@@ -210,9 +217,16 @@ class SprykConfig
      */
     public function getProjectNamespaces(): array
     {
+        $namespaces = [];
+        $namespacesFromEnv = getenv('PROJECT_NAMESPACES');
+        if ($namespacesFromEnv) {
+            /** @var string $namespacesFromEnv */
+            $namespaces = explode(',', $namespacesFromEnv);
+        }
+
         return Config::get(
             KernelConstants::PROJECT_NAMESPACES,
-            getenv('PROJECT_NAMESPACES') ? explode(',', getenv('PROJECT_NAMESPACES')) : [],
+            $namespaces,
         );
     }
 

--- a/src/SprykerSdk/Spryk/SprykConfig.php
+++ b/src/SprykerSdk/Spryk/SprykConfig.php
@@ -193,7 +193,7 @@ class SprykConfig
     {
         return Config::get(
             KernelConstants::CORE_NAMESPACES,
-            getenv('CORE_NAMESPACES') ? explode(',', getenv('CORE_NAMESPACES')) : []
+            getenv('CORE_NAMESPACES') ? explode(',', getenv('CORE_NAMESPACES')) : [],
         );
     }
 
@@ -202,7 +202,7 @@ class SprykConfig
      */
     public function getProjectNamespace(): ?string
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACE, getenv('PROJECT_NAMESPACE') ?:'');
+        return Config::get(KernelConstants::PROJECT_NAMESPACE, getenv('PROJECT_NAMESPACE') ?: '');
     }
 
     /**
@@ -212,7 +212,7 @@ class SprykConfig
     {
         return Config::get(
             KernelConstants::PROJECT_NAMESPACES,
-            getenv('PROJECT_NAMESPACES') ? explode(',', getenv('PROJECT_NAMESPACES')) : []
+            getenv('PROJECT_NAMESPACES') ? explode(',', getenv('PROJECT_NAMESPACES')) : [],
         );
     }
 


### PR DESCRIPTION
- Developer(s): @gechetspr

- Ticket: 

- Docs PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/3928

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Spryk

##### Change log

Fixes

- Adjusted `SprykConfig::getCoreNamespaces()` in order to get namespaces from the env variable by default.
- Adjusted `SprykConfig::getProjectNamespaces()` in order to get namespaces from the env variable by default.
- Adjusted `SprykConfig::getProjectNamespace()` in order to get namespaces from the env variable by default.

