### PR TITLE
TE-10740 Fixed wrong namespace during autogeneration yves module

### DIFF
--- a/config/spryk/templates/Yves/YvesWidget.php.twig
+++ b/config/spryk/templates/Yves/YvesWidget.php.twig
@@ -2,7 +2,7 @@
 
 {{ include('Partials/license.twig') }}
 
-namespace {{ organization }}\Yves\{{ module }};
+namespace {{ organization }}\Yves\{{ module }}\Widget;
 
 use Spryker\Yves\Kernel\Widget\AbstractWidget;
 


### PR DESCRIPTION
- Developer(s): @geega

- Ticket: https://spryker.atlassian.net/browse/TE-10740

- Docs PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/4019

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk                 | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Spryk

##### Change log

Fixes
- Adjusted template `YvesWidget.php.twig`  fixed wrong namespace.
