### PR TITLE
FRW-998 Dropped PHP 8.0 and added PHP 8.2 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [
-            '8.1'
+            '8.2'
         ]
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spryk Module
 [![CI](https://github.com/spryker-sdk/spryk/workflows/CI/badge.svg?branch=master)](https://github.com/spryker-sdk/spryk/actions?query=workflow%3ACI+branch%3Amaster)
 [![Latest Stable Version](https://poser.pugx.org/spryker-sdk/spryk/v/stable.svg)](https://packagist.org/packages/spryker-sdk/spryk)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat)](https://github.com/phpstan/phpstan)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Spryk module",
     "license": "proprietary",
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
- Developer(s): @yaroslav-spryker  

- Ticket: https://spryker.atlassian.net/browse/FRW-998

- Release Group: https://release.spryker.com/release-groups/view/5084

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Spryk             | patch (currently 0.x)          |                       |

-----------------------------------------

#### Module EventBehavior

##### Change log

Improvements 

- Added `PHP 8.2` support.

